### PR TITLE
Prescribe the config plugin integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add `hypertrack-sdk-expo` to [`plugins`](https://docs.expo.io/versions/latest/co
       [
         "hypertrack-sdk-expo",
         {
-          "publishableKey: "YourPublishableKey", // find this in the HyperTrack dashboard
+          "publishableKey": "YourPublishableKey", // find this in the HyperTrack dashboard
           "automaticallyRequestPermissions": false,
           "allowMockLocations": false,
           "loggingEnabled": true,


### PR DESCRIPTION
We were missing new SDK configuration properties in our README, this should better guide anyone trying to integrate our config plugin in their expo app.

Closes #13 